### PR TITLE
Add the missing id attrib to section tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
 
 
     <!-- About Me Section  -->
-    <section class="about-section">
+    <section class="about-section" id="about-section">
         <h2 class="common-heading text-center">More About Me</h2>
 
         <div class="sub-container">


### PR DESCRIPTION
- The `section` **about-section** is missing the `id` used in the navbar's `href`
- This causes a bug where clicking the `About Me` doesn't scroll to its `href`